### PR TITLE
Updates for pep8 compliance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ coverage.xml
 
 # PyBuilder
 target/
+
+history.txt # Ignore this because running the program generates it.


### PR DESCRIPTION
Some of the long assert lines required more than just whitespace
changes.  In one case, ensuring that -p and -c aren't used at the same
time is now done using the argparse feature for that, replacing the
assert.  In other cases, a new function error_and_exit was added that
prints the arguments of the error message to stderr, then exits with a
non-zero return value.  Then, the asserts are replaced with an if
statement and a call to error_and_exit.

Also, it is my impression that normally asserts are meant to be used
to guard against programmer causes errors and not for printing error
messages about user causes errors.